### PR TITLE
Added missing `-imageExistsForKey:` method

### DIFF
--- a/SYCache.h
+++ b/SYCache.h
@@ -66,6 +66,7 @@
 
 - (UIImage *)imageForKey:(NSString *)key;
 - (void)imageForKey:(NSString *)key usingBlock:(void (^)(UIImage *image))block;
+- (BOOL)imageExistsForKey:(NSString *)key;
 - (void)setImage:(UIImage *)image forKey:(NSString *)key;
 
 @end

--- a/SYCache.m
+++ b/SYCache.m
@@ -246,6 +246,9 @@
 	});
 }
 
+- (BOOL)imageExistsForKey:(NSString *)key {
+    return [self objectExistsForKey:[[self class] _keyForImageKey:key]];
+}
 
 - (void)setImage:(UIImage *)image forKey:(NSString *)key {
 	if (!image) {


### PR DESCRIPTION
Hi. I've added an `-imageExistsForKey:` method to `UIImageAdditions` category to check if the image is in cache.

(Sorry for two separate commits, I've done them in web editor).
